### PR TITLE
Add publishing of the provider. Trigger on release workflow success

### DIFF
--- a/.github/workflows/publish-provider.yml
+++ b/.github/workflows/publish-provider.yml
@@ -1,0 +1,104 @@
+name: Publish Terraform Provider
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: publish
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ github.event.workflow_run.head_branch }} --repo ${{ github.repository }} --dir dist/
+
+      - name: Extract short version
+        id: extract_version
+        run: |
+          TAG_NAME="${{ github.event.workflow_run.head_branch }}"
+          SHORT_VERSION=$(echo "$TAG_NAME" | sed -E 's/v([0-9]+\.[0-9]+\.[0-9]+)-.*/\1/')
+          FULL_VERSION=$(echo "$TAG_NAME" | sed -E 's/v//')
+          echo "short_version=$SHORT_VERSION" >> $GITHUB_ENV
+          echo "full_version=$FULL_VERSION" >> $GITHUB_ENV
+
+      - name: Create version.json
+        run: |
+          cat <<EOF > version.json
+          {
+            "data": {
+              "type": "registry-provider-versions",
+              "attributes": {
+                "version": "${{ env.short_version }}",
+                "key-id": "${{ vars.TFE_KEY_ID }}",
+                "protocols": ["5.0"]
+              }
+            }
+          }
+          EOF
+
+      - name: Create provider version in Terraform Enterprise
+        id: create_version
+        env:
+          TOKEN: ${{ secrets.TFE_TOKEN }}
+        run: |
+          RESPONSE=$(curl -s -X POST \
+            --header "Authorization: Bearer $TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            --data @version.json \
+            https://app.terraform.io/api/v2/organizations/GR-OSS/registry-providers/private/GR-OSS/github/versions)
+
+          echo "shasums_upload=$(echo $RESPONSE | jq -r '.data.links."shasums-upload"')" >> $GITHUB_ENV
+          echo "shasums_sig_upload=$(echo $RESPONSE | jq -r '.data.links."shasums-sig-upload"')" >> $GITHUB_ENV
+
+      - name: Upload SHA256SUMS
+        run: |
+          curl -T dist/terraform-provider-github_${{ env.full_version }}_SHA256SUMS ${{ env.shasums_upload }}
+
+      - name: Upload SHA256SUMS.sig
+        run: |
+          curl -T dist/terraform-provider-github_${{ env.full_version }}_SHA256SUMS.sig ${{ env.shasums_sig_upload }}
+
+      - name: Process and Upload Provider Binaries
+        env:
+          TOKEN: ${{ secrets.TFE_TOKEN }}
+        run: |
+          for file in dist/*.zip; do
+          filename=$(basename "$file")
+          os=$(echo $filename | awk -F'_' '{print $(NF-1)}')
+          arch=$(echo $filename | awk -F'_' '{print $NF}' | sed 's/.zip//')
+          shasum=$(sha256sum $file | awk '{print $1}')
+
+          cat <<EOF > platform.json
+          {
+            "data": {
+              "type": "registry-provider-platforms",
+              "attributes": {
+                "os": "$os",
+                "arch": "$arch",
+                "shasum": "$shasum",
+                "filename": "$filename"
+              }
+            }
+          }
+          EOF
+
+          PLATFORM_RESPONSE=$(curl -s -X POST \
+            --header "Authorization: Bearer $TOKEN" \
+            --header "Content-Type: application/vnd.api+json" \
+            --data @platform.json \
+            https://app.terraform.io/api/v2/organizations/GR-OSS/registry-providers/private/GR-OSS/github/versions/${{ env.short_version }}/platforms)
+          
+          provider_binary_upload=$(echo $PLATFORM_RESPONSE | jq -r '.data.links."provider-binary-upload"')
+
+          curl -T "$file" "$provider_binary_upload"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ terraform-provider-github
 
 # do not commit secrets
 .env
+dist/


### PR DESCRIPTION
This PR adds only the publishing of the provider to TFE. In gitignore, just added dist dir created by goreleaser in Release workflow (for easer maintenance later)

Prereq:

- [x] create an env `publish` for `main` branch that will have:
  - [x] a secret `TFE_TOKEN` set
  - [x] a variable TFE_KEY_ID = 3AAFE0237464B9EB
- [x] add repository secrets (in Security > Secrets and variables > Actions):
  - [x] `GPG_PRIVATE_KEY`
  - [x] `PASSPHRASE`

secrets will be shared securely