### PR TITLE
fix: call Read after Create and Update in deployment policy resource

### DIFF
--- a/github/resource_github_repository_environment_deployment_policy.go
+++ b/github/resource_github_repository_environment_deployment_policy.go
@@ -98,7 +98,7 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyCreate(ctx context.Conte
 	}
 
 	d.SetId(buildThreePartID(repoName, escapedEnvName, strconv.FormatInt(resultKey.GetID(), 10)))
-	return nil
+	return resourceGithubRepositoryEnvironmentDeploymentPolicyRead(ctx, d, meta)
 }
 
 func resourceGithubRepositoryEnvironmentDeploymentPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -173,7 +173,7 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyUpdate(ctx context.Conte
 		return diag.FromErr(err)
 	}
 	d.SetId(buildThreePartID(repoName, escapedEnvName, strconv.FormatInt(resultKey.GetID(), 10)))
-	return nil
+	return resourceGithubRepositoryEnvironmentDeploymentPolicyRead(ctx, d, meta)
 }
 
 func resourceGithubRepositoryEnvironmentDeploymentPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {


### PR DESCRIPTION
Create and Update both set the resource ID but return nil without populating branch_pattern/tag_pattern in state. Terraform then calls Read to verify the new state, finds no attributes set, and reports 'Root object was present, but now absent'.

Fix: delegate to Read at the end of both Create and Update so state is populated immediately after the API call succeeds.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

